### PR TITLE
Allow parenthesis to be preserved

### DIFF
--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -190,7 +190,7 @@ export function getReprinter(path: any) {
               let     endColumn       = origEnd.column;
 
               if ((node as any).comments) {
-                  let     lastComment     = (node as any).comments.at (-1);
+                  let     lastComment     = (node as any).comments[(node as any).comments.length-1];
                   let     commentsEnd     = lastComment.loc.end;
 
                   // only process same-line situations

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -181,7 +181,6 @@ export function getReprinter(path: any) {
       if (path.getName () !== 'callee') {
           // console.log (`- got argument`);
           let     origIndex   = origParentNode.arguments.findIndex ((n: any) => n === orig);
-          console.log (`- origIndex: ${origIndex}`);
 
           if (origIndex !== -1) {
               // Let's process starting point
@@ -197,7 +196,6 @@ export function getReprinter(path: any) {
                   // Also, assuming leading comments
                   if ( origStart.line === commentsEnd.line &&
                        commentsEnd.column <= origStart.column) {
-                          console.log (`- commentsEnd: ${commentsEnd.column}, origStart: ${origStart.column}`);
                           startColumn     = commentsEnd.column;
                           // Lets take a ride until non-whitespace is encountered
                           while (origLoc.lines.charAt ({line: origStart.line, column: startColumn}) === ' ') {

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -212,7 +212,7 @@ export function getReprinter(path: any) {
               // Let's process the ending point
               if (origIndex !== origParentNode.arguments.length-1) {
                   // Not last element
-                  console.log (`- not last argument`);
+                  // console.log (`- not last argument`);
                   let     nextArgNode     = origParentNode.arguments[origIndex+1];
                   let     nextArgStart    = nextArgNode.loc.start;
 

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -190,12 +190,13 @@ export function getReprinter(path: any) {
               let     endColumn       = origEnd.column;
 
               if ((node as any).comments) {
-                  let     commentsEnd = (node as any).comments.at (-1).loc.end;
+                  let     lastComment     = (node as any).comments.at (-1);
+                  let     commentsEnd     = lastComment.loc.end;
 
                   // only process same-line situations
                   // Also, assuming leading comments
                   if ( origStart.line === commentsEnd.line &&
-                       commentsEnd.column <= origStart.column) {
+                       lastComment.leading ) {
                           startColumn     = commentsEnd.column;
                           // Lets take a ride until non-whitespace is encountered
                           while (origLoc.lines.charAt ({line: origStart.line, column: startColumn}) === ' ') {

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -180,7 +180,7 @@ export function getReprinter(path: any) {
        origParentNode?.type === 'CallExpression' ) {
       if (path.getName () !== 'callee') {
           // console.log (`- got argument`);
-          let     origIndex   = origParentNode.arguments.findIndex (n => n === orig);
+          let     origIndex   = origParentNode.arguments.findIndex ((n: any) => n === orig);
           console.log (`- origIndex: ${origIndex}`);
 
           if (origIndex !== -1) {

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -833,15 +833,15 @@ function runTestsForParser(parserId: any) {
       ["// comment", ";(function() {})();"].join(eol),
     );
   });
-  
+
   pit("should preserve comments attached to CallExpression argument", function () {
     const code = 'testFunc (/** @type {string} */ (a), b);';
     const ast = recast.parse(code, { parser });
     const args = ast.program.body[0].expression.arguments;
-    
+
     args.unshift(args[1]);
-    const expected = 'testFunc(b, /** @type {string} */ a, b);';
-    
+    const expected = 'testFunc(b, /** @type {string} */ (a), b);';
+
     assert.strictEqual(recast.print(ast).code, expected);
   });
 
@@ -850,14 +850,14 @@ function runTestsForParser(parserId: any) {
         'hello.world; // has computed value',
         'hello["world"]; // has computed value',
     ].join(eol);
-    
+
     const ast = recast.parse(code, { parser });
-    
+
     const expected = [
         'hello.world; // has computed value',
         'hello["world"]; // has computed value',
     ].join(eol);
-    
+
     assert.strictEqual(recast.print(ast).code, expected);
   });
 }


### PR DESCRIPTION
Should preserve spacing now. 

```js
                let     js_source       = [
                        // `function a () {`,
                        `        testFunc (/** @type {string} */ (a), b);`,
                        `        testFunc1A (/** @type {string} */ (a), b, {c: 1, d: 1});`,
                        `        testFunc2A (/** @type {string} */ (a), b);`,
                        // `}`,
                ].join ('\n');


recastVisit (js_ast, {
                        visitCallExpression:    function (path1) {
                                if (path1.value.callee.name === 'testFunc') {
                                        return false;
                                }
                                else if (path1.value.callee.name === 'testFunc1A') {
                                        this.traverse (path1);
                                }

                                if (path1.value.callee.name === 'testFunc2A') {
                                        path1.value.arguments.unshift (astTypes.builders.identifier ('newOpt'));
                                }
                                else if (path1.value.callee.name === 'testFunc1A') {
                                        path1.value.arguments[1].name   = 'b123456789';
                                }

                                return false;
                        },

                        /**
                         * @param {*} path1
                         * @returns
                         */
                        visitObjectExpression:  function (path1) {
                                let     prop0   = path1.value.properties[0];
                                prop0.key.name  = 'c000';
                                return false;
                        },

                });
```